### PR TITLE
Basemapper allow for in memory BytesIO GeoJSON for boundary param #204

### DIFF
--- a/Outreachy.py
+++ b/Outreachy.py
@@ -1,0 +1,21 @@
+from io import BytesIO
+import os
+from osm_fieldwork.basemapper import create_basemap_file
+
+basepath = os.path.dirname(os.path.abspath(__file__))
+filepath = f"{basepath}\\tests\\testdata\\Sample.geojson"
+sampletest = f"{basepath}\\tests\\testdata\\testingdata.geojson"
+
+
+with open(filepath, "rb") as geojson_file:
+    boundary = geojson_file.read()  # read as a `bytes` object.
+    boundary_bytesio = BytesIO(boundary)   # add to a BytesIO wrapper
+
+
+create_basemap_file(
+    verbose=True,
+    boundary=boundary_bytesio,
+    outfile="toogood.mbtiles",
+    zooms="15-17",
+    source="esri",
+)


### PR DESCRIPTION
 ### Summary of the Changes I made on this Pull Request

- [1]  The `main() method` was modified to read the parameters of the boundary given as coordinates or GeoJSON format. The `main() method` now reads the GeoJSON file immediately as it is passed into the `main() method` and converts it into a `BytesIO` format, which is then passed into the `create_basemap_file` which calls the `basemapper.py` class. 

- [2] The `basemapper.py` class was configured to accept `BytesIO` and string(coordinates) which can then be used to create the image tile from the source. 

- [3] An `outreachy.py` file was created to run a Python test case by passing coordinates and GeoJSON file from disk, which gave a successful response.

- [4] Comments were included in the codebase to improve the code readability, and action performed by the caller method.

- [5] A test script was added to the `test/test_basemap.py` to test the codebase ability to increase the zoom from "8-11" to "12-17" and esri was added as source to the basemapper parameters. 
